### PR TITLE
Read Clumper.read_jsonl implementation

### DIFF
--- a/clumper/clump.py
+++ b/clumper/clump.py
@@ -90,8 +90,6 @@ class Clumper:
         # Reached here so there are no errors. Parse the array to Clumper object
         return Clumper(data_array)
 
-        return Clumper(data_array)
-
     def _create_new(self, blob):
         """
         Creates a new collection of data while preserving settings of the

--- a/clumper/clump.py
+++ b/clumper/clump.py
@@ -1,5 +1,6 @@
 import json
 import pathlib
+import jsonlines
 import itertools as it
 import urllib.request
 from functools import reduce
@@ -61,6 +62,35 @@ class Clumper:
                 data = json.loads(resp.read())
             return Clumper(data)
         return Clumper(json.loads(pathlib.Path(path).read_text()))
+
+    @classmethod
+    def read_jsonl(cls, path, lines=None):
+        """
+        Reads in a jsonl file. You can also specify how many lines you want to read in.
+
+        """
+        data_array = []
+        # Case 1 : Handle local files
+        if path.startswith("https:") and path.startswith("http:"):
+            raise ValueError(
+                "Currently the jsonl files must be in the local machine. Please specify a local file."
+            )
+        else:
+            try:
+                with jsonlines.open(path) as f:
+                    for current_line_nr, line_data in enumerate(f):
+                        if lines is not None and current_line_nr > lines:
+                            break
+                        else:
+                            data_array.append(line_data)
+            except Exception:
+                print("Error occured during reading reading jsonl file")
+                raise
+
+        # Reached here so there are no errors. Parse the array to Clumper object
+        return Clumper(data_array)
+
+        return Clumper(data_array)
 
     def _create_new(self, blob):
         """

--- a/clumper/clump.py
+++ b/clumper/clump.py
@@ -79,7 +79,7 @@ class Clumper:
             try:
                 with jsonlines.open(path) as f:
                     for current_line_nr, line_data in enumerate(f):
-                        if lines is not None and current_line_nr > lines:
+                        if lines is not None and current_line_nr > lines - 1:
                             break
                         else:
                             data_array.append(line_data)

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,10 @@ test_packages = [
     "pytest>=5.4.3",
     "black>=19.10b0",
     "flake8>=3.8.3",
+    "pytest-datafiles>=2.0",
 ]
 
-util_packages = ["jupyterlab>=2.2.0", "pre-commit>=2.6.0"]
+util_packages = ["jupyterlab>=2.2.0", "jsonline>==1.2.0", "pre-commit>=2.6.0"]
 
 docs_packages = [
     "mkdocs>=1.1",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ test_packages = [
     "pytest-datafiles>=2.0",
 ]
 
-util_packages = ["jupyterlab>=2.2.0", "jsonline>==1.2.0", "pre-commit>=2.6.0"]
+util_packages = ["jupyterlab>=2.2.0", "jsonlines>==1.2.0", "pre-commit>=2.6.0"]
 
 docs_packages = [
     "mkdocs>=1.1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,3 +9,7 @@ def base_clumper():
         for i, c in enumerate("abcdefghijklmnopqrstuvwxyz")
     ]
     return Clumper(data)
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "datafiles: load datafiles")

--- a/tests/test_read_write/sample_jsonl_files/cards.jsonl
+++ b/tests/test_read_write/sample_jsonl_files/cards.jsonl
@@ -1,0 +1,4 @@
+{"name": "Gilbert", "wins": [["straight", "7♣"], ["one pair", "10♥"]]}
+{"name": "Alexa", "wins": [["two pair", "4♠"], ["two pair", "9♠"]]}
+{"name": "May", "wins": []}
+{"name": "Deloise", "wins": [["three of a kind", "5♣"]]}

--- a/tests/test_read_write/test_read_jsonl.py
+++ b/tests/test_read_write/test_read_jsonl.py
@@ -4,7 +4,7 @@ from clumper import Clumper
 
 
 @pytest.mark.datafiles("./tests/test_read_write/sample_jsonl_files/cards.jsonl")
-def test_read_jsonl_local(datafiles):
+def test_read_jsonl_all_lines(datafiles):
     path = str(datafiles)  # Convert from py.path object to path (str)
 
     file_path = str(os.path.join(path, "cards.jsonl"))
@@ -12,3 +12,12 @@ def test_read_jsonl_local(datafiles):
     assert (
         len(Clumper.read_jsonl(file_path)) == 4
     )  # There are 4 rows in the sample file
+
+
+@pytest.mark.datafiles("./tests/test_read_write/sample_jsonl_files/cards.jsonl")
+def test_read_jsonl_limited_lines(datafiles):
+    path = str(datafiles)  # Convert from py.path object to path (str)
+
+    file_path = str(os.path.join(path, "cards.jsonl"))
+    assert os.path.isfile(file_path)  # Make sure its a file
+    assert len(Clumper.read_jsonl(file_path, lines=2)) == 2

--- a/tests/test_read_write/test_read_jsonl.py
+++ b/tests/test_read_write/test_read_jsonl.py
@@ -1,0 +1,14 @@
+import pytest
+import os
+from clumper import Clumper
+
+
+@pytest.mark.datafiles("./tests/test_read_write/sample_jsonl_files/cards.jsonl")
+def test_read_jsonl_local(datafiles):
+    path = str(datafiles)  # Convert from py.path object to path (str)
+
+    file_path = str(os.path.join(path, "cards.jsonl"))
+    assert os.path.isfile(file_path)  # Make sure its a file
+    assert (
+        len(Clumper.read_jsonl(file_path)) == 4
+    )  # There are 4 rows in the sample file


### PR DESCRIPTION
Can only handle local jsonl file for the moment. Next allow ability to provide files stored in the cloud. Perhaps also the possibility to import multiple jsonl files limited by the `lines` parameter. 