### PR TITLE
allow Clumper to read Path files and glob

### DIFF
--- a/clumper/clump.py
+++ b/clumper/clump.py
@@ -80,6 +80,9 @@ class Clumper:
             if n <= 0:
                 raise ValueError("Number of lines to read must be > 0.")
 
+        # Quick conversion in case of Path object
+        path = str(path)
+
         if path.startswith("https:") or path.startswith("http:"):
             with urllib.request.urlopen(path) as resp:
                 data = json.loads(resp.read())
@@ -120,6 +123,9 @@ class Clumper:
             if n <= 0:
                 raise ValueError("Number of lines to read must be > 0.")
 
+        # Quick conversion in case of Path object
+        path = str(path)
+
         # Case 1 : Open cloud file in stream
         if path.startswith("https:") or path.startswith("http:"):
             f = urllib.request.urlopen(path)
@@ -141,7 +147,7 @@ class Clumper:
 
     @classmethod
     @multifile()
-    def read_yaml(cls, path: str, n=None, listify=True):
+    def read_yaml(cls, path, n=None, listify=True):
         """
         Reads in a yaml file.
 
@@ -174,6 +180,10 @@ class Clumper:
         assert len(clump) == 6
         ```
         """
+
+        # Quick conversion in case of Path object
+        path = str(path)
+
         # Case 1 : Open cloud file in stream
         if path.startswith(("https:", "http:")):
             f = urllib.request.urlopen(path)
@@ -332,7 +342,9 @@ class Clumper:
 
         # conveniently excludes pathlib files here and removes
         # the need to write code to check pathlib files in other places.
-        if isinstance(path, str) and path.startswith(("https:", "http:")):
+        # Quick conversion in case of Path object
+        path = str(path)
+        if path.startswith(("https:", "http:")):
             with urllib.request.urlopen(path) as resp:
                 if fieldnames is None:
                     fieldnames = resp.readline().decode().strip().split(",")

--- a/clumper/decorators.py
+++ b/clumper/decorators.py
@@ -2,6 +2,7 @@ from functools import wraps, reduce
 from copy import deepcopy
 import inspect
 from glob import glob
+from pathlib import Path
 
 
 def return_value_if_empty(value=None):
@@ -85,16 +86,33 @@ def multifile(param_name="path"):
 
             # If * not in path then let the default function handle it.
             # We are only interested if the path has * in it
+            if isinstance(path, str):
+                if "*" not in path:
+                    return f(*args, **kwargs)
+                else:
+                    # Else, create a glob out of it
+                    path_list = glob(path)
 
-            if "*" not in str(path):
+            # Let default function handle single Path objects
+            elif isinstance(path, Path):
                 return f(*args, **kwargs)
 
-            # Else, create a glob out of it
-            path_list = glob(path)
+            # Handle a list of Path objects
+            elif isinstance(path, (list)):
+                path_list = []
+                for p in path:
+                    if isinstance(p, Path):
+                        path_list.append(p)
+                    else:
+                        raise ValueError(f"Invalid path: {p}")
+            else:
+                raise ValueError(
+                    f"{path} is not a valid string, Path, or list of Paths"
+                )
 
             # No files found given the pattern so raise error
             if len(path_list) == 0:
-                raise ValueError(f"No files files given pattern : {path}")
+                raise ValueError(f"No files found given pattern : {path}")
 
             # Store the parsed clumpers here
             collected_clumpers = []

--- a/tests/test_decorator/test_multifile.py
+++ b/tests/test_decorator/test_multifile.py
@@ -1,10 +1,12 @@
 from clumper import Clumper
 import pytest
+from pathlib import Path
 
 
 def test_non_existent_pattern(tmp_path):
     with pytest.raises(ValueError):
         Clumper.read_json(str(tmp_path / "*.json"))
+        Clumper.read_json(list(Path(tmp_path).glob("*.json")))
 
 
 @pytest.mark.parametrize("copies", [1, 5, 10])
@@ -19,6 +21,9 @@ def test_read_multiple_jsonl(tmp_path, copies):
         writer.write_jsonl(tmp_path / f"cards_copy_{i}.jsonl")
 
     reader = Clumper.read_jsonl(str(tmp_path / "*.jsonl"))
+    assert len(reader) == copies * len(writer)
+
+    reader = Clumper.read_jsonl(list(Path(tmp_path).glob("*.jsonl")))
     assert len(reader) == copies * len(writer)
 
 
@@ -36,6 +41,9 @@ def test_read_multiple_json(tmp_path, copies):
     reader = Clumper.read_json(str(tmp_path / "*.json"))
     assert len(reader) == copies * len(writer)
 
+    reader = Clumper.read_json(list(Path(tmp_path).glob("*.json")))
+    assert len(reader) == copies * len(writer)
+
 
 @pytest.mark.parametrize("copies", [1, 5, 10])
 def test_read_multiple_csv(tmp_path, copies):
@@ -51,11 +59,14 @@ def test_read_multiple_csv(tmp_path, copies):
     reader = Clumper.read_csv(str(tmp_path / "*.csv"))
     assert len(reader) == copies * len(writer)
 
+    reader = Clumper.read_csv(list(Path(tmp_path).glob("*.csv")))
+    assert len(reader) == copies * len(writer)
+
 
 @pytest.mark.parametrize("copies", [1, 5, 10])
 def test_read_multiple_yaml(tmp_path, copies):
     """
-    Test that csv files can be read given a pattern
+    Test that yaml files can be read given a pattern
     """
 
     writer = Clumper.read_yaml("tests/data/demo-nested.yml")
@@ -64,4 +75,7 @@ def test_read_multiple_yaml(tmp_path, copies):
         writer.write_yaml(tmp_path / f"demo-nested-{i}.yml")
 
     reader = Clumper.read_yaml(str(tmp_path / "*.yml"))
+    assert len(reader) == copies * len(writer)
+
+    reader = Clumper.read_yaml(list(Path(tmp_path).glob("*.yml")))
     assert len(reader) == copies * len(writer)


### PR DESCRIPTION
Addresses #65 .

- Fixed a typo where "csv" should have been "yaml".
- Removed "str" type hint from `read_yaml()`. 
- Added more tests for feature

I removed the type hint from `read_yaml()` since the function no longer only accepts `str`. However, I think it's probably best to add typing to all of functions just so users and linters are aware. That can be done in a different PR though.