### PR TITLE
Datetime rounding 

### DIFF
--- a/clumper/__init__.py
+++ b/clumper/__init__.py
@@ -1,1 +1,2 @@
 from clumper.clump import Clumper
+from clumper.functions import round_dt_str

--- a/clumper/functions.py
+++ b/clumper/functions.py
@@ -1,0 +1,58 @@
+from datetime import datetime, timedelta
+
+SUPPORTED_FREQUENCIES = ["seconds", "minutes", "hours", "days", "months"]
+
+
+def get_datetime_component(dt: datetime, component: str):
+    if component == "seconds":
+        return dt.second
+
+    if component == "minutes":
+        return dt.minute
+
+    if component == "hours":
+        return dt.hour
+
+    if component == "days":
+        return dt.day - 1
+
+    if component == "months":
+        return dt
+
+
+def round_dt_str(
+    dt_str: str,
+    frequency: str,
+    dt_format: str = "%Y-%m-%d %H:%M:%S.%f",
+):
+    """Rounds datetime to the nearest frequency. The default format is assumed to be ISO 8601 datetime format.
+    You can specify your own format as well. For simplicity, the timezone is not taken into consideration.
+
+    Args:
+        dt_str (str): The datetime in string.
+        frequency(str): The frequency to round the datetime.
+        dt_format (str, optional): The datetime format. Defaults to ISO 8601 datetime format.
+
+
+    Raises:
+        TypeError: If the given frequency is not suppored
+
+    Returns:
+        str: The rounded datetime
+    """
+
+    if frequency not in SUPPORTED_FREQUENCIES:
+        raise TypeError(
+            f"given frequency {frequency} is not supported, please select one from {SUPPORTED_FREQUENCIES}"
+        )
+
+    dt = datetime.strptime(dt_str, dt_format)
+
+    frequencies_to_update = {
+        SUPPORTED_FREQUENCIES[i]: get_datetime_component(dt, SUPPORTED_FREQUENCIES[i])
+        for i in range(SUPPORTED_FREQUENCIES.index(frequency))
+    }
+
+    new_dt = dt - timedelta(microseconds=dt.microsecond, **frequencies_to_update)
+
+    return new_dt.strftime(dt_format)

--- a/tests/test_mappers/test_round_dt.py
+++ b/tests/test_mappers/test_round_dt.py
@@ -1,0 +1,24 @@
+import pytest
+from clumper import round_dt_str
+
+
+def test_invalid_format_dt_round_str():
+    """Checks that invalid datetime format raises error"""
+    with pytest.raises(ValueError):
+        round_dt_str("2019-01-01 01:01:59", "minutes", "%m/%d/%Y, %H:%M:%S")
+
+
+@pytest.mark.parametrize(
+    "non_rounded_datetime, frequency,rounded_datetime",
+    [
+        ("2021-04-03 12:20:32.805052", "seconds", "2021-04-03 12:20:32.000000"),
+        ("2021-04-03 12:20:32.805052", "minutes", "2021-04-03 12:20:00.000000"),
+        ("2021-04-03 12:20:36.805052", "hours", "2021-04-03 12:00:00.000000"),
+        ("2021-04-03 12:20:36.805052", "days", "2021-04-03 00:00:00.000000"),
+        ("2021-04-03 12:20:36.805052", "months", "2021-04-01 00:00:00.000000"),
+    ],
+)
+def test_round_iso_8601_datetime(non_rounded_datetime, frequency, rounded_datetime):
+    assert (
+        round_dt_str(non_rounded_datetime, frequency) == rounded_datetime
+    ), "Rounded datetime is not correct"


### PR DESCRIPTION
Currently supporting `"seconds", "minutes", "hours", "days", "months"`. It's in the plan to add `years` but it becomes complicated as `timedelta` doesn't allow `months` as parameter. I suppose they didn't wanted to support it as days per month can vary.
